### PR TITLE
various fixes required to get an example Cartfile to build (Swift 3)

### DIFF
--- a/punic/checkout.py
+++ b/punic/checkout.py
@@ -83,6 +83,6 @@ class Checkout(object):
             cache_identifier = '{},{}'.format(str(rev), project_path.relative_to(self.checkout_path))
             return cache_identifier
 
-        project_paths = self.checkout_path.glob("*.xcodeproj")
+        project_paths = self.checkout_path.glob("**/*.xcodeproj")
         projects = [XcodeProject(self, config.xcode, project_path, _make_cache_identifier(project_path)) for project_path in project_paths]
         return projects

--- a/punic/checkout.py
+++ b/punic/checkout.py
@@ -32,7 +32,7 @@ class Checkout(object):
                 if flag == ' ':
                     pass
                 elif flag == '-':
-                    raise Exception('Uninitialized submodule P{. Please report this!'.format(self.checkout_path))
+                    raise Exception('Uninitialized submodule {}. Please report this!'.format(self.checkout_path))
                 elif flag == '+':
                     raise Exception('Submodule {} doesn\'t match expected revision'.format(self.checkout_path))
                 elif flag == 'U':

--- a/punic/checkout.py
+++ b/punic/checkout.py
@@ -27,7 +27,7 @@ class Checkout(object):
 
             result = runner.run('git submodule status "{}"'.format(relative_checkout_path))
             if result.return_code == 0:
-                match = re.match(r'^(?P<flag> |\-|\+|U)(?P<sha>[a-f0-9]+) (?P<path>.+) \((?P<description>.+)\)', result.stdout)
+                match = re.match(r'^(?P<flag> |\-|\+|U)(?P<sha>[a-f0-9]+) (?P<path>.+)( \((?P<description>.+)\))?', result.stdout)
                 flag = match.groupdict()['flag']
                 if flag == ' ':
                     pass

--- a/punic/xcode.py
+++ b/punic/xcode.py
@@ -223,7 +223,6 @@ class XcodeBuildArguments(object):
             'CODE_SIGNING_REQUIRED': 'NO',
             'CODE_SIGN_IDENTITY': '',
             'CARTHAGE': 'YES',
-            'SWIFT_VERSION': '2.3', # TODO: WHAT?
         }
 
         if arguments:


### PR DESCRIPTION
I'm playing around with punic and threw the following Cartfile at it (subset of real Cartfile at work):

    github "samsonjs/ReSwift"
    github "samsonjs/YapDatabase"
    github "samsonjs/CacheCreek"
    github "samsonjs/Promise"

The changes in this PR were all required to get it to build.

9bf3013: The output of `git submodule status` with git 2.9.3 from homebrew does not include a description for me.

20dfc5b: Removed hard-coded Swift version from build arguments. This worked for me but may break things for other configurations. Not sure if this is a general fix.

125335b: [Reachability](https://github.com/tonymillion/Reachability) doesn't have its Xcode project in the repo root, it's in the Framework subdirectory. This commit changes the glob to search subdirectories. This may be pretty slow in large repos so maybe it could be limited to searching only 1-2 levels deep instead of infinitely deep.