### PR TITLE
Add Watch and TV targets, Improve semantic version pattern

### DIFF
--- a/punic/platform.py
+++ b/punic/platform.py
@@ -32,7 +32,8 @@ class Platform(object):
 Platform.all = [
     Platform(name='iOS', nickname='iOS', sdks=['iphoneos', 'iphonesimulator'], output_directory_name='iOS'),
     Platform(name='macOS', nickname='Mac', sdks=['macosx'], output_directory_name='Mac'),
-    # TODO add watchos and tvos
+    Platform(name='watchOS', nickname='watchOS', sdks=['watchos'], output_directory_name='watchOS'),
+    Platform(name='tvOS', nickname='tvOS', sdks=['tvos'], output_directory_name='tvOS'),
 ]
 
 

--- a/punic/semantic_version.py
+++ b/punic/semantic_version.py
@@ -9,7 +9,7 @@ from functools import total_ordering
 @total_ordering
 class SemanticVersion(object):
 
-    expression = re.compile(r'^(?P<prefix>[a-z]+)?(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?(?:-(?P<identifiers>.+))?$')
+    expression = re.compile(r'^(?P<prefix>[a-z,_]+)?(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?(?:-(?P<identifiers>.+))?$', re.I)
 
     @classmethod
     def is_semantic(cls, s):


### PR DESCRIPTION
This PR adds support for watchOS and tvOS targets.
Also improves the expression handling because `https://github.com/DaveWoodCom/XCGLogger` has versioned his library like `Version_4.0.0` and the pattern was failing to find the version number in that string.