### PR TITLE
Add more simulator platforms, update tests to use python 3.6, update tests to use Xcode 8.2

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -6,7 +6,7 @@
         <value>
           <list size="2">
             <item index="0" class="java.lang.String" itemvalue="2.7" />
-            <item index="1" class="java.lang.String" itemvalue="3.5" />
+            <item index="1" class="java.lang.String" itemvalue="3.6" />
           </list>
         </value>
       </option>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.2
 install:
 #- brew install python # Looks like python is already installed now.
-- brew install python3
-- pip install nose
-- pip install tox
+- pip install --user nose
+- pip install --user tox
+- brew install --user python3
+- pip3 install --user nose
+- pip3 install --user tox
 script:
 - tox
 

--- a/punic/platform.py
+++ b/punic/platform.py
@@ -32,7 +32,7 @@ class Platform(object):
 Platform.all = [
     Platform(name='iOS', nickname='iOS', sdks=['iphoneos', 'iphonesimulator'], output_directory_name='iOS'),
     Platform(name='macOS', nickname='Mac', sdks=['macosx'], output_directory_name='Mac'),
-    Platform(name='watchOS', nickname='watchOS', sdks=['watchos'], output_directory_name='watchOS'),
+    Platform(name='watchOS', nickname='watchOS', sdks=['watchos', 'watchsimulator'], output_directory_name='watchOS'),
     Platform(name='tvOS', nickname='tvOS', sdks=['tvos'], output_directory_name='tvOS'),
 ]
 

--- a/punic/platform.py
+++ b/punic/platform.py
@@ -33,7 +33,7 @@ Platform.all = [
     Platform(name='iOS', nickname='iOS', sdks=['iphoneos', 'iphonesimulator'], output_directory_name='iOS'),
     Platform(name='macOS', nickname='Mac', sdks=['macosx'], output_directory_name='Mac'),
     Platform(name='watchOS', nickname='watchOS', sdks=['watchos', 'watchsimulator'], output_directory_name='watchOS'),
-    Platform(name='tvOS', nickname='tvOS', sdks=['tvos'], output_directory_name='tvOS'),
+    Platform(name='tvOS', nickname='tvOS', sdks=['appletvos', 'appletvsimulator'], output_directory_name='tvOS')
 ]
 
 

--- a/punic/test/Examples/ReactiveCocoa/punic.yaml
+++ b/punic/test/Examples/ReactiveCocoa/punic.yaml
@@ -1,4 +1,4 @@
 defaults:
   configuration: Debug
   platform: Mac
-  xcode-version: 7.3.1
+  xcode: Xcode 8.2

--- a/punic/test/Examples/SwiftIO/Cartfile
+++ b/punic/test/Examples/SwiftIO/Cartfile
@@ -1,1 +1,1 @@
-github "schwa/SwiftIO" == 0.1.14
+github "schwa/SwiftIO" == 0.3

--- a/punic/test/Examples/SwiftIO/punic.yaml
+++ b/punic/test/Examples/SwiftIO/punic.yaml
@@ -1,4 +1,4 @@
 defaults:
   configuration: Debug
   platform: Mac
-  xcode-version: 7.3.1
+  xcode: Xcode 8.2

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: MacOS :: MacOS X',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Build Tools',
         ],
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py35
+envlist = py27,py36
 
 [testenv]
 commands = nosetests punic


### PR DESCRIPTION
## What this does 

- Currently punic only builds for the watch device, This adds the `watchsimulator` sdk to the `watchOS` platform as well as `appletvsimulator` to `appletvos` so that we can build for the watch and tv simulators too:
<img width="207" alt="screenshot 2017-01-05 01 52 59" src="https://cloud.githubusercontent.com/assets/228140/21671490/b862ec12-d2e9-11e6-89e6-8ff45f5df059.png">

- As of late December, `brew install python3` installs python 3.6 instead of 3.5, so this also updates to use python 3.6 for the test suite.
- Since the latest version of Xcode is 8.2.x I think it is good idea to keep the tests up to date, so this also changes to use Xcode 8.2 on travis along with updating SwiftIO to 0.3 so that it can build on Xcode 8.2. If you prefer, we could keep 7.3 or do both(?)