### PR TITLE
Fixes sematic version parsing for uppercase prefix

### DIFF
--- a/punic/semantic_version.py
+++ b/punic/semantic_version.py
@@ -9,7 +9,7 @@ from functools import total_ordering
 @total_ordering
 class SemanticVersion(object):
 
-    expression = re.compile(r'^(?P<prefix>[a-z,_]+)?(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?(?:-(?P<identifiers>.+))?$', re.I)
+    expression = re.compile(r'^(?P<prefix>[a-z,A-Z,_]+)?(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?(?:-(?P<identifiers>.+))?$', re.I)
 
     @classmethod
     def is_semantic(cls, s):


### PR DESCRIPTION
The library [XCGLogger](https://github.com/DaveWoodCom/XCGLogger) uses the semantic version formate with an uppercase `Version_` prefix.
This PR adds the uppercase `A-Z` to the prefix in the regex.