### PR TITLE
.xcworkspace

### DIFF
--- a/punic/checkout.py
+++ b/punic/checkout.py
@@ -80,6 +80,7 @@ class Checkout(object):
             os.symlink("../../../Build", str(carthage_symlink_path))
 
     projectExpression = re.compile(r"\.xcodeproj/[^/]+\.xcworkspace$")
+    playgroundExpression = re.compile(r"\.playground/[^/]+\.xcworkspace$")
     @property
     def projects(self):
         def _make_cache_identifier(project_path):
@@ -103,7 +104,7 @@ class Checkout(object):
         projects = []
         schemes = []
         for project_path in project_paths:
-            if Checkout.projectExpression.search(str(project_path)):
+            if Checkout.projectExpression.search(str(project_path)) or Checkout.playgroundExpression.search(str(project_path)):
                 continue
             project = XcodeProject(self, config.xcode, project_path, _make_cache_identifier(project_path))
             for scheme in list(project.scheme_names):

--- a/punic/xcode.py
+++ b/punic/xcode.py
@@ -152,7 +152,7 @@ class XcodeProject(object):
         # type: (str, XcodeBuildArguments) -> [str]
         assert not arguments or isinstance(arguments, XcodeBuildArguments)
         arguments = arguments.to_list() if arguments else []
-        command = ['xcodebuild', '-project', self.path] + arguments + [subcommand]
+        command = ['xcodebuild', '-project' if self.path.suffix =='.xcodeproj' else '-workspace', self.path] + arguments + [subcommand]
         return self.xcode.check_call(command, **kwargs)
 
 


### PR DESCRIPTION
*`Punic` now also works with .xcworkspace files.*

It looks for them in the Checkout folder and can run `xcodebuild` with the `-workspace` command.

Because each .xcworkspace also has a .xcodeproj we need to avoid duplicate builds of the same scheme by removing duplicate scheme names.

If I did understand the `carthage` code correctly, they do it the same way.

This change is necessary to build `realm-cocoa`, but you still need to add a skip for `RealmExamples`.

Sorry for the bad `python` code, but I've never coded in python and all I do is more or less trail and error. I'd appreciate a review.