### PR TITLE
Survive mdfind failure

### DIFF
--- a/punic/xcode.py
+++ b/punic/xcode.py
@@ -50,6 +50,13 @@ class Xcode(object):
             Xcode._all_xcodes = all_xcodes
 
             default_developer_dir_path = Path(runner.check_run(['xcode-select', '-p']).strip())
+            mdfind_failed = len(all_xcodes) == 0
+            if mdfind_failed:
+                # Back up from /Applications/Xcode.app/Contents/Developer to
+                # /Application/Xcode.app and build an Xcode around that.
+                fallback = default_developer_dir_path.parent.parent
+                all_xcodes = [Xcode(fallback)]
+                Xcode._all_xcodes = all_xcodes
             Xcode._default_xcode = [xcode for xcode in all_xcodes if xcode.developer_dir_path == default_developer_dir_path][0]
             Xcode._default_xcode.is_default = True
 

--- a/punic/xcode.py
+++ b/punic/xcode.py
@@ -42,7 +42,11 @@ class Xcode(object):
     def find_all(cls):
         if Xcode._all_xcodes is None:
             output = runner.check_run('/usr/bin/mdfind \'kMDItemCFBundleIdentifier="com.apple.dt.Xcode" and kMDItemContentType="com.apple.application-bundle"\'')
-            all_xcodes = [Xcode(Path(path)) for path in output.strip().split("\n")]
+            all_xcodes = [
+                Xcode(Path(path))
+                for path in output.strip().split("\n")
+                if len(path) > 0  # otherwise empty output processes [u""]
+                ]
             Xcode._all_xcodes = all_xcodes
 
             default_developer_dir_path = Path(runner.check_run(['xcode-select', '-p']).strip())


### PR DESCRIPTION
If the `mdfind` search for Xcode apps fails, then `punic` can't even dump its help info:

```
> punic --help
Traceback (most recent call last):
  File "/usr/local/bin/punic", line 7, in <module>
    from punic.punic_cli import main
  File "/usr/local/lib/python2.7/site-packages/punic/__init__.py", line 13, in <module>
    from .checkout import Checkout
  File "/usr/local/lib/python2.7/site-packages/punic/checkout.py", line 7, in <module>
    from punic.config import config
  File "/usr/local/lib/python2.7/site-packages/punic/config.py", line 135, in <module>
    config = Config()
  File "/usr/local/lib/python2.7/site-packages/punic/config.py", line 43, in __init__
    self.xcode = Xcode.default()
  File "/usr/local/lib/python2.7/site-packages/punic/xcode.py", line 23, in default
    Xcode.find_all()
  File "/usr/local/lib/python2.7/site-packages/punic/xcode.py", line 49, in find_all
    Xcode._default_xcode = [xcode for xcode in all_xcodes if xcode.developer_dir_path == default_developer_dir_path][0]
IndexError: list index out of range
```

This PR recovers by working backwards from the `xcode_select -p` output to create an `Xcode` instance to act as the default Xcode.