### PR TITLE
Better support for Github Enterprise

### DIFF
--- a/punic/specification.py
+++ b/punic/specification.py
@@ -85,6 +85,12 @@ class ProjectIdentifier(object):
         'foo/bar'
         >>> ProjectIdentifier.string('github "foo/bar"').full_identifier
         'github "foo/bar"'
+        >>> ProjectIdentifier.string('github "https://github.enterprise.com/foo/bar"').team_name
+        'foo'
+        >>> ProjectIdentifier.string('github "https://github.enterprise.com/foo/bar"').project_name
+        'bar'
+        >>> ProjectIdentifier.string('github "https://github.enterprise.com/foo/bar.git"').project_name
+        'bar'
         >>> ProjectIdentifier.string('git "file:///Users/example/Projects/Example-Project"')
         Example-Project
         >>> ProjectIdentifier.string('git "git@gitlab.com:mokagio/punic-cartfile-issue.git"')
@@ -102,16 +108,18 @@ class ProjectIdentifier(object):
         link = match.group('link')
 
         if source == 'github':
-            match = re.match(r'^(?P<team_name>[^/]+)/(?P<project_name>[^/]+)$', link)
+            match = re.match(r'(?P<remote_url>(?:.*?)(?:/|:))*(?P<team_name>[^/]+)/(?P<project_name>[^/]+)$', link)
             if not match:
                 raise Exception('No match')
             team_name = match.group('team_name')
             project_name = match.group('project_name')
+            remote_url = match.group('remote_url') or 'github.com/'
 
-            if not use_ssh:
-                remote_url = 'https://github.com/{}/{}.git'.format(team_name, project_name)
-            else:
-                remote_url = 'git@github.com:{}/{}.git'.format(team_name, project_name)
+            match = re.match(r'.+\.git$', link)
+            suffix = '' if match else '.git'
+
+            scheme = 'git@' if use_ssh else 'https://'
+            remote_url = '{}{}{}/{}{}'.format(scheme, remote_url, team_name, project_name, suffix)
         elif source == 'git':
             team_name = None
             url_parts = urlparse.urlparse(link)

--- a/punic/specification.py
+++ b/punic/specification.py
@@ -91,6 +91,8 @@ class ProjectIdentifier(object):
         'bar'
         >>> ProjectIdentifier.string('github "https://github.enterprise.com/foo/bar.git"').project_name
         'bar'
+        >>> ProjectIdentifier.string('github "https://github.enterprise.com/foo/bar.git"').remote_url
+        'https://github.enterprise.com/foo/bar.git'
         >>> ProjectIdentifier.string('git "file:///Users/example/Projects/Example-Project"')
         Example-Project
         >>> ProjectIdentifier.string('git "git@gitlab.com:mokagio/punic-cartfile-issue.git"')
@@ -108,18 +110,15 @@ class ProjectIdentifier(object):
         link = match.group('link')
 
         if source == 'github':
-            match = re.match(r'(?P<remote_url>(?:.*?)(?:/|:))*(?P<team_name>[^/]+)/(?P<project_name>[^/]+)$', link)
+            match = re.match(r'(?P<remote_url>(?:.*?)(?:/|:))*(?P<team_name>[^/]+)/(?P<project_name>[^/]+?)(?:\.git)?$', link)
             if not match:
                 raise Exception('No match')
             team_name = match.group('team_name')
             project_name = match.group('project_name')
             remote_url = match.group('remote_url') or 'github.com/'
 
-            match = re.match(r'.+\.git$', link)
-            suffix = '' if match else '.git'
-
             scheme = 'git@' if use_ssh else 'https://'
-            remote_url = '{}{}{}/{}{}'.format(scheme, remote_url, team_name, project_name, suffix)
+            remote_url = '{}{}{}/{}.git'.format(scheme, remote_url, team_name, project_name)
         elif source == 'git':
             team_name = None
             url_parts = urlparse.urlparse(link)

--- a/testing/Examples/rx/punic.yaml
+++ b/testing/Examples/rx/punic.yaml
@@ -1,4 +1,4 @@
 defaults:
   configuration: Debug
   platform: Mac
-  xcode-version: 8.3
+  xcode-version: 8.3.2


### PR DESCRIPTION
Added better support for Github Enterprise specs.
Like:
`github "https://github.enterprise.com/foo/bar"`
`github "https://github.enterprise.com/foo/bar.git"`

