### PR TITLE
support 'file://~/' to config repo-override path

### DIFF
--- a/punic/specification.py
+++ b/punic/specification.py
@@ -139,7 +139,12 @@ class ProjectIdentifier(object):
         if overrides and self.project_name in overrides:
             override_url = overrides[self.project_name]
             logging.info('Overriding {} with git URL {}'.format(self.project_name, override_url))
-            self.remote_url = override_url
+            if override_url.startswith("file://~/") :
+                user = os.environ["USER"]
+                url = override_url.replace("file://~/", "file:///Users/{}/".format(user))
+                self.remote_url = url
+            else:
+                self.remote_url = override_url
 
     @mproperty
     def full_identifier(self):


### PR DESCRIPTION
support 'file://~/' to config repo-override path